### PR TITLE
Implement basic UI for user and admin screens

### DIFF
--- a/lib/admin/add_restaurant.dart
+++ b/lib/admin/add_restaurant.dart
@@ -1,13 +1,45 @@
 import 'package:flutter/material.dart';
 
-class AddRestaurantScreen extends StatelessWidget {
+class AddRestaurantScreen extends StatefulWidget {
   const AddRestaurantScreen({super.key});
+
+  @override
+  State<AddRestaurantScreen> createState() => _AddRestaurantScreenState();
+}
+
+class _AddRestaurantScreenState extends State<AddRestaurantScreen> {
+  final _nameController = TextEditingController();
+  final _addressController = TextEditingController();
+  final _cuisineController = TextEditingController();
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Add Restaurant')),
-      body: const Center(child: Text('Add Restaurant Form')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: [
+            TextField(
+              controller: _nameController,
+              decoration: const InputDecoration(labelText: 'Name'),
+            ),
+            TextField(
+              controller: _addressController,
+              decoration: const InputDecoration(labelText: 'Address'),
+            ),
+            TextField(
+              controller: _cuisineController,
+              decoration: const InputDecoration(labelText: 'Cuisine'),
+            ),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('Save'),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/admin/admin_dashboard.dart
+++ b/lib/admin/admin_dashboard.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'manage_restaurants.dart';
+import 'review_management.dart';
 
 class AdminDashboard extends StatelessWidget {
   const AdminDashboard({super.key});
@@ -7,7 +9,65 @@ class AdminDashboard extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Admin Dashboard')),
-      body: const Center(child: Text('Admin Dashboard')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: const [
+                _StatCard(label: 'Restaurants', value: '3'),
+                _StatCard(label: 'Reviews', value: '2'),
+              ],
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                      builder: (_) => const ManageRestaurantsScreen()),
+                );
+              },
+              child: const Text('Manage Restaurants'),
+            ),
+            const SizedBox(height: 8),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                      builder: (_) => const ReviewManagementScreen()),
+                );
+              },
+              child: const Text('Review Management'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _StatCard extends StatelessWidget {
+  final String label;
+  final String value;
+  const _StatCard({required this.label, required this.value});
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: [
+            Text(value, style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold)),
+            const SizedBox(height: 4),
+            Text(label),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/admin/edit_restaurant.dart
+++ b/lib/admin/edit_restaurant.dart
@@ -1,13 +1,55 @@
 import 'package:flutter/material.dart';
+import '../models/restaurant_model.dart';
 
-class EditRestaurantScreen extends StatelessWidget {
-  const EditRestaurantScreen({super.key});
+class EditRestaurantScreen extends StatefulWidget {
+  final Restaurant restaurant;
+  const EditRestaurantScreen({super.key, required this.restaurant});
+
+  @override
+  State<EditRestaurantScreen> createState() => _EditRestaurantScreenState();
+}
+
+class _EditRestaurantScreenState extends State<EditRestaurantScreen> {
+  late TextEditingController _nameController;
+  late TextEditingController _addressController;
+  late TextEditingController _cuisineController;
+
+  @override
+  void initState() {
+    super.initState();
+    _nameController = TextEditingController(text: widget.restaurant.name);
+    _addressController = TextEditingController(text: widget.restaurant.address);
+    _cuisineController = TextEditingController(text: widget.restaurant.cuisine);
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Edit Restaurant')),
-      body: const Center(child: Text('Edit Restaurant Form')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: [
+            TextField(
+              controller: _nameController,
+              decoration: const InputDecoration(labelText: 'Name'),
+            ),
+            TextField(
+              controller: _addressController,
+              decoration: const InputDecoration(labelText: 'Address'),
+            ),
+            TextField(
+              controller: _cuisineController,
+              decoration: const InputDecoration(labelText: 'Cuisine'),
+            ),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('Update'),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/admin/login_screen.dart
+++ b/lib/admin/login_screen.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'admin_dashboard.dart';
+
+class AdminLoginScreen extends StatefulWidget {
+  const AdminLoginScreen({super.key});
+
+  @override
+  State<AdminLoginScreen> createState() => _AdminLoginScreenState();
+}
+
+class _AdminLoginScreenState extends State<AdminLoginScreen> {
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Admin Login')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: [
+            TextField(
+              controller: _emailController,
+              decoration: const InputDecoration(labelText: 'Email'),
+            ),
+            TextField(
+              controller: _passwordController,
+              decoration: const InputDecoration(labelText: 'Password'),
+              obscureText: true,
+            ),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.pushReplacement(
+                  context,
+                  MaterialPageRoute(builder: (_) => const AdminDashboard()),
+                );
+              },
+              child: const Text('Login'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/admin/manage_menus.dart
+++ b/lib/admin/manage_menus.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import '../models/restaurant_model.dart';
+import '../models/menu_model.dart';
+
+class ManageMenusScreen extends StatefulWidget {
+  final Restaurant restaurant;
+  const ManageMenusScreen({super.key, required this.restaurant});
+
+  @override
+  State<ManageMenusScreen> createState() => _ManageMenusScreenState();
+}
+
+class _ManageMenusScreenState extends State<ManageMenusScreen> {
+  late List<MenuItem> _menu;
+
+  @override
+  void initState() {
+    super.initState();
+    _menu = List<MenuItem>.from(widget.restaurant.menu);
+  }
+
+  void _addItem() {
+    setState(() {
+      _menu.add(MenuItem(id: DateTime.now().toString(), name: 'New Item', price: 0));
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Manage Menu - ${widget.restaurant.name}')),
+      floatingActionButton: FloatingActionButton(
+        onPressed: _addItem,
+        child: const Icon(Icons.add),
+      ),
+      body: ListView.builder(
+        itemCount: _menu.length,
+        itemBuilder: (context, index) {
+          final item = _menu[index];
+          return ListTile(
+            title: Text(item.name),
+            subtitle: Text('\\$${item.price.toStringAsFixed(2)}'),
+            trailing: IconButton(
+              icon: const Icon(Icons.delete),
+              onPressed: () => setState(() => _menu.removeAt(index)),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/admin/manage_restaurants.dart
+++ b/lib/admin/manage_restaurants.dart
@@ -1,13 +1,105 @@
 import 'package:flutter/material.dart';
+import '../models/restaurant_model.dart';
+import '../services/restaurant_service.dart';
+import 'add_restaurant.dart';
+import 'edit_restaurant.dart';
+import 'manage_menus.dart';
 
-class ManageRestaurantsScreen extends StatelessWidget {
+class ManageRestaurantsScreen extends StatefulWidget {
   const ManageRestaurantsScreen({super.key});
+
+  @override
+  State<ManageRestaurantsScreen> createState() => _ManageRestaurantsScreenState();
+}
+
+class _ManageRestaurantsScreenState extends State<ManageRestaurantsScreen> {
+  final RestaurantService _service = RestaurantService();
+  List<Restaurant> _restaurants = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final data = await _service.fetchRestaurants();
+    setState(() => _restaurants = data);
+  }
+
+  void _confirmDelete(Restaurant restaurant) {
+    showDialog(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('Delete Restaurant?'),
+        content: Text('Remove ${restaurant.name}?'),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(context), child: const Text('Cancel')),
+          TextButton(onPressed: () => Navigator.pop(context), child: const Text('Delete')),
+        ],
+      ),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Manage Restaurants')),
-      body: const Center(child: Text('Manage Restaurants')),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(builder: (_) => const AddRestaurantScreen()),
+          );
+        },
+        child: const Icon(Icons.add),
+      ),
+      body: _restaurants.isEmpty
+          ? const Center(child: CircularProgressIndicator())
+          : ListView.builder(
+              itemCount: _restaurants.length,
+              itemBuilder: (context, index) {
+                final r = _restaurants[index];
+                return Card(
+                  margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                  child: ListTile(
+                    title: Text(r.name),
+                    subtitle: Text(r.cuisine),
+                    trailing: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        IconButton(
+                          icon: const Icon(Icons.restaurant_menu),
+                          onPressed: () {
+                            Navigator.push(
+                              context,
+                              MaterialPageRoute(
+                                builder: (_) => ManageMenusScreen(restaurant: r),
+                              ),
+                            );
+                          },
+                        ),
+                        IconButton(
+                          icon: const Icon(Icons.edit),
+                          onPressed: () {
+                            Navigator.push(
+                              context,
+                              MaterialPageRoute(
+                                builder: (_) => EditRestaurantScreen(restaurant: r),
+                              ),
+                            );
+                          },
+                        ),
+                        IconButton(
+                          icon: const Icon(Icons.delete),
+                          onPressed: () => _confirmDelete(r),
+                        ),
+                      ],
+                    ),
+                  ),
+                );
+              },
+            ),
     );
   }
 }

--- a/lib/admin/review_management.dart
+++ b/lib/admin/review_management.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+
+class ReviewManagementScreen extends StatefulWidget {
+  const ReviewManagementScreen({super.key});
+
+  @override
+  State<ReviewManagementScreen> createState() => _ReviewManagementScreenState();
+}
+
+class _ReviewManagementScreenState extends State<ReviewManagementScreen> {
+  final List<Map<String, dynamic>> _reviews = [
+    {'user': 'John Doe', 'rating': 8, 'comment': 'Great food!'},
+    {'user': 'Sarah Smith', 'rating': 9, 'comment': 'Amazing service!'},
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Review Management')),
+      body: ListView.builder(
+        itemCount: _reviews.length,
+        itemBuilder: (context, index) {
+          final review = _reviews[index];
+          return Card(
+            margin: const EdgeInsets.all(8),
+            child: ListTile(
+              title: Text(review['user']),
+              subtitle: Text(review['comment']),
+              leading: CircleAvatar(child: Text(review['rating'].toString())),
+              trailing: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  IconButton(
+                    icon: const Icon(Icons.check, color: Colors.green),
+                    onPressed: () {},
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.close, color: Colors.red),
+                    onPressed: () {},
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,122 +1,21 @@
 import 'package:flutter/material.dart';
+import 'screens/splash_screen.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(const DineHubApp());
 }
 
-class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+class DineHubApp extends StatelessWidget {
+  const DineHubApp({super.key});
 
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Flutter Demo',
+      title: 'DineHub',
       theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+        primarySwatch: Colors.red,
       ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
-    );
-  }
-}
-
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text('You have pushed the button this many times:'),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
+      home: const SplashScreen(),
     );
   }
 }

--- a/lib/models/menu_model.dart
+++ b/lib/models/menu_model.dart
@@ -2,6 +2,12 @@ class MenuItem {
   final String id;
   final String name;
   final double price;
+  final bool available;
 
-  MenuItem({required this.id, required this.name, required this.price});
+  MenuItem({
+    required this.id,
+    required this.name,
+    required this.price,
+    this.available = true,
+  });
 }

--- a/lib/models/restaurant_model.dart
+++ b/lib/models/restaurant_model.dart
@@ -1,6 +1,21 @@
+import 'menu_model.dart';
+
 class Restaurant {
   final String id;
   final String name;
+  final String cuisine;
+  final double rating;
+  final String distance;
+  final String address;
+  final List<MenuItem> menu;
 
-  Restaurant({required this.id, required this.name});
+  Restaurant({
+    required this.id,
+    required this.name,
+    required this.cuisine,
+    required this.rating,
+    required this.distance,
+    required this.address,
+    this.menu = const [],
+  });
 }

--- a/lib/screens/about_screen.dart
+++ b/lib/screens/about_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../widgets/bottom_nav.dart';
 
 class AboutScreen extends StatelessWidget {
   const AboutScreen({super.key});
@@ -7,7 +8,23 @@ class AboutScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('About')),
-      body: const Center(child: Text('About Screen')),
+      bottomNavigationBar: const DineHubNavBar(currentIndex: 2),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: const [
+            Text('DineHub', style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold)),
+            SizedBox(height: 8),
+            Text('Discover Amazing Restaurants'),
+            SizedBox(height: 16),
+            Text('Features:'),
+            Text('• Restaurant discovery'),
+            Text('• Location-based search'),
+            Text('• User reviews & ratings'),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/screens/add_review_dialog.dart
+++ b/lib/screens/add_review_dialog.dart
@@ -1,17 +1,47 @@
 import 'package:flutter/material.dart';
+import '../models/restaurant_model.dart';
 
-class AddReviewDialog extends StatelessWidget {
-  const AddReviewDialog({super.key});
+class AddReviewDialog extends StatefulWidget {
+  final Restaurant restaurant;
+  const AddReviewDialog({super.key, required this.restaurant});
+
+  @override
+  State<AddReviewDialog> createState() => _AddReviewDialogState();
+}
+
+class _AddReviewDialogState extends State<AddReviewDialog> {
+  double _rating = 5;
+  final TextEditingController _controller = TextEditingController();
 
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
-      title: const Text('Add Review'),
-      content: const Text('Review form goes here'),
+      title: Text('Review ${widget.restaurant.name}'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Slider(
+            value: _rating,
+            min: 0,
+            max: 10,
+            divisions: 10,
+            label: _rating.round().toString(),
+            onChanged: (v) => setState(() => _rating = v),
+          ),
+          TextField(
+            controller: _controller,
+            decoration: const InputDecoration(hintText: 'Comment (optional)'),
+          ),
+        ],
+      ),
       actions: [
         TextButton(
           onPressed: () => Navigator.of(context).pop(),
-          child: const Text('Close'),
+          child: const Text('Cancel'),
+        ),
+        ElevatedButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Submit'),
         ),
       ],
     );

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,13 +1,62 @@
 import 'package:flutter/material.dart';
+import '../models/restaurant_model.dart';
+import '../services/restaurant_service.dart';
+import '../widgets/restaurant_card.dart';
+import '../widgets/bottom_nav.dart';
 
-class HomeScreen extends StatelessWidget {
+class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
+
+  @override
+  State<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
+  final RestaurantService _service = RestaurantService();
+  List<Restaurant> _restaurants = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final data = await _service.fetchRestaurants();
+    setState(() => _restaurants = data);
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Home')),
-      body: const Center(child: Text('Home Screen')),
+      appBar: AppBar(title: const Text('DineHub')),
+      bottomNavigationBar: const DineHubNavBar(currentIndex: 0),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: TextField(
+              decoration: InputDecoration(
+                hintText: 'Search restaurants...',
+                prefixIcon: const Icon(Icons.search),
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(30),
+                ),
+              ),
+            ),
+          ),
+          Expanded(
+            child: _restaurants.isEmpty
+                ? const Center(child: CircularProgressIndicator())
+                : ListView.builder(
+                    itemCount: _restaurants.length,
+                    itemBuilder: (context, index) {
+                      return RestaurantCard(restaurant: _restaurants[index]);
+                    },
+                  ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/screens/map_view_screen.dart
+++ b/lib/screens/map_view_screen.dart
@@ -1,13 +1,27 @@
 import 'package:flutter/material.dart';
+import '../models/restaurant_model.dart';
+import '../widgets/bottom_nav.dart';
 
 class MapViewScreen extends StatelessWidget {
-  const MapViewScreen({super.key});
+  final Restaurant? restaurant;
+  const MapViewScreen({super.key, this.restaurant});
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Map View')),
-      body: const Center(child: Text('Map View Screen')),
+      appBar: AppBar(
+          title: Text(restaurant != null ? restaurant!.name : 'Map View')),
+      bottomNavigationBar: const DineHubNavBar(currentIndex: 1),
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.map, size: 100, color: Colors.grey),
+            const SizedBox(height: 16),
+            Text(restaurant?.address ?? 'Map placeholder'),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/screens/restaurant_detail_screen.dart
+++ b/lib/screens/restaurant_detail_screen.dart
@@ -1,13 +1,60 @@
 import 'package:flutter/material.dart';
+import '../models/restaurant_model.dart';
+import '../widgets/bottom_nav.dart';
+import 'map_view_screen.dart';
+import 'add_review_dialog.dart';
 
 class RestaurantDetailScreen extends StatelessWidget {
-  const RestaurantDetailScreen({super.key});
+  final Restaurant restaurant;
+  const RestaurantDetailScreen({super.key, required this.restaurant});
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Restaurant Details')),
-      body: const Center(child: Text('Restaurant Detail Screen')),
+      appBar: AppBar(title: Text(restaurant.name)),
+      bottomNavigationBar: const DineHubNavBar(currentIndex: 0),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          Text(
+            restaurant.name,
+            style: Theme.of(context).textTheme.headlineSmall,
+          ),
+          const SizedBox(height: 8),
+          Text(restaurant.address),
+          const SizedBox(height: 8),
+          Text('Rating: ${restaurant.rating.toStringAsFixed(1)}'),
+          const SizedBox(height: 16),
+          const Text('Menu', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+          const SizedBox(height: 8),
+          ...restaurant.menu.map((item) => ListTile(
+                title: Text(item.name),
+                trailing: Text('\\$${item.price.toStringAsFixed(2)}'),
+              )),
+          const SizedBox(height: 16),
+          ElevatedButton(
+            onPressed: () {
+              showDialog(
+                context: context,
+                builder: (_) => AddReviewDialog(restaurant: restaurant),
+              );
+            },
+            child: const Text('Add Review'),
+          ),
+          const SizedBox(height: 8),
+          ElevatedButton(
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => MapViewScreen(restaurant: restaurant),
+                ),
+              );
+            },
+            child: const Text('View on Map'),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/screens/splash_screen.dart
+++ b/lib/screens/splash_screen.dart
@@ -1,12 +1,50 @@
 import 'package:flutter/material.dart';
+import 'home_screen.dart';
 
-class SplashScreen extends StatelessWidget {
+class SplashScreen extends StatefulWidget {
   const SplashScreen({super.key});
 
   @override
+  State<SplashScreen> createState() => _SplashScreenState();
+}
+
+class _SplashScreenState extends State<SplashScreen> {
+  @override
+  void initState() {
+    super.initState();
+    Future.delayed(const Duration(seconds: 2), () {
+      Navigator.pushReplacement(
+        context,
+        MaterialPageRoute(builder: (_) => const HomeScreen()),
+      );
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return const Scaffold(
-      body: Center(child: Text('Splash Screen')),
+    return Scaffold(
+      body: Container(
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            colors: [Color(0xFF667EEA), Color(0xFF764BA2)],
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+          ),
+        ),
+        child: const Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                '🍽️',
+                style: TextStyle(fontSize: 64),
+              ),
+              SizedBox(height: 16),
+              CircularProgressIndicator(color: Colors.white),
+            ],
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/services/restaurant_service.dart
+++ b/lib/services/restaurant_service.dart
@@ -1,8 +1,49 @@
+import '../models/menu_model.dart';
 import '../models/restaurant_model.dart';
 
 class RestaurantService {
   Future<List<Restaurant>> fetchRestaurants() async {
-    // Placeholder implementation
-    return [];
+    // Simulated network delay
+    await Future.delayed(const Duration(milliseconds: 500));
+
+    return [
+      Restaurant(
+        id: '1',
+        name: 'Pizza Palace',
+        cuisine: 'Italian',
+        rating: 4.5,
+        distance: '2.1km',
+        address: '123 Main Street, Downtown',
+        menu: [
+          MenuItem(id: 'm1', name: 'Margherita Pizza', price: 12.99),
+          MenuItem(id: 'm2', name: 'Pepperoni Pizza', price: 14.99),
+          MenuItem(id: 'm3', name: 'Caesar Salad', price: 8.50, available: false),
+        ],
+      ),
+      Restaurant(
+        id: '2',
+        name: 'Ramen Corner',
+        cuisine: 'Japanese',
+        rating: 4.2,
+        distance: '1.8km',
+        address: '456 Elm Street',
+        menu: [
+          MenuItem(id: 'm4', name: 'Shoyu Ramen', price: 10.99),
+          MenuItem(id: 'm5', name: 'Miso Ramen', price: 11.99),
+        ],
+      ),
+      Restaurant(
+        id: '3',
+        name: 'Green Garden',
+        cuisine: 'Healthy',
+        rating: 4.7,
+        distance: '0.5km',
+        address: '789 Oak Avenue',
+        menu: [
+          MenuItem(id: 'm6', name: 'Quinoa Salad', price: 9.99),
+          MenuItem(id: 'm7', name: 'Veggie Bowl', price: 12.50),
+        ],
+      ),
+    ];
   }
 }

--- a/lib/widgets/bottom_nav.dart
+++ b/lib/widgets/bottom_nav.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import '../screens/home_screen.dart';
+import '../screens/map_view_screen.dart';
+import '../screens/about_screen.dart';
+
+class DineHubNavBar extends StatelessWidget {
+  final int currentIndex;
+  const DineHubNavBar({super.key, required this.currentIndex});
+
+  void _navigate(BuildContext context, int index) {
+    if (index == currentIndex) return;
+    Widget destination;
+    switch (index) {
+      case 0:
+        destination = const HomeScreen();
+        break;
+      case 1:
+        destination = const MapViewScreen();
+        break;
+      default:
+        destination = const AboutScreen();
+    }
+    Navigator.pushReplacement(
+      context,
+      MaterialPageRoute(builder: (_) => destination),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BottomNavigationBar(
+      currentIndex: currentIndex,
+      onTap: (i) => _navigate(context, i),
+      items: const [
+        BottomNavigationBarItem(icon: Icon(Icons.home), label: 'Home'),
+        BottomNavigationBarItem(icon: Icon(Icons.map), label: 'Map'),
+        BottomNavigationBarItem(icon: Icon(Icons.info), label: 'About'),
+      ],
+    );
+  }
+}

--- a/lib/widgets/restaurant_card.dart
+++ b/lib/widgets/restaurant_card.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../models/restaurant_model.dart';
+import '../screens/restaurant_detail_screen.dart';
 
 class RestaurantCard extends StatelessWidget {
   final Restaurant restaurant;
@@ -9,8 +10,29 @@ class RestaurantCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       child: ListTile(
+        leading: CircleAvatar(
+          child: Text(restaurant.name.substring(0, 1)),
+        ),
         title: Text(restaurant.name),
+        subtitle: Row(
+          children: [
+            Text('${restaurant.rating.toStringAsFixed(1)}★'),
+            const SizedBox(width: 8),
+            Text(restaurant.cuisine),
+            const SizedBox(width: 8),
+            Text(restaurant.distance),
+          ],
+        ),
+        onTap: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (_) => RestaurantDetailScreen(restaurant: restaurant),
+            ),
+          );
+        },
       ),
     );
   }


### PR DESCRIPTION
## Summary
- Add splash screen, home listing, restaurant details and shared bottom navigation
- Scaffold admin dashboard with restaurant CRUD, menu management and review moderation
- Introduce mock data models and services powering sample UI

## Testing
- `dart format lib` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894726f01f08323a821420ffeca740c