### PR TITLE
Fix admin imports and database usage for menus and restaurants

### DIFF
--- a/lib/admin/edit_restaurant.dart
+++ b/lib/admin/edit_restaurant.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import '../models/restaurant_model.dart';
+import '../models/restaurant.dart';
 
 class EditRestaurantScreen extends StatefulWidget {
   final Restaurant restaurant;

--- a/lib/admin/manage_menus.dart
+++ b/lib/admin/manage_menus.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
-import '../models/restaurant_model.dart';
-import '../models/menu_model.dart';
+import '../models/restaurant.dart';
+import '../models/menu_item.dart';
+import '../services/database_service.dart';
 
 class ManageMenusScreen extends StatefulWidget {
   final Restaurant restaurant;
@@ -11,17 +12,32 @@ class ManageMenusScreen extends StatefulWidget {
 }
 
 class _ManageMenusScreenState extends State<ManageMenusScreen> {
-  late List<MenuItem> _menu;
+  final DatabaseService _db = DatabaseService();
+  List<MenuItem> _menu = [];
 
   @override
   void initState() {
     super.initState();
-    _menu = List<MenuItem>.from(widget.restaurant.menu);
+    _loadMenu();
+  }
+
+  Future<void> _loadMenu() async {
+    final restaurantId = widget.restaurant.id;
+    if (restaurantId != null) {
+      final items = await _db.getMenuItems(restaurantId);
+      setState(() => _menu = items);
+    }
   }
 
   void _addItem() {
     setState(() {
-      _menu.add(MenuItem(id: DateTime.now().toString(), name: 'New Item', price: 0));
+      _menu.add(
+        MenuItem(
+          restaurantId: widget.restaurant.id ?? 0,
+          name: 'New Item',
+          price: 0.0,
+        ),
+      );
     });
   }
 

--- a/lib/admin/manage_restaurants.dart
+++ b/lib/admin/manage_restaurants.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-import '../models/restaurant_model.dart';
-import '../services/restaurant_service.dart';
+import '../models/restaurant.dart';
+import '../services/database_service.dart';
 import 'add_restaurant.dart';
 import 'edit_restaurant.dart';
 import 'manage_menus.dart';
@@ -13,7 +13,7 @@ class ManageRestaurantsScreen extends StatefulWidget {
 }
 
 class _ManageRestaurantsScreenState extends State<ManageRestaurantsScreen> {
-  final RestaurantService _service = RestaurantService();
+  final DatabaseService _service = DatabaseService();
   List<Restaurant> _restaurants = [];
 
   @override
@@ -23,7 +23,7 @@ class _ManageRestaurantsScreenState extends State<ManageRestaurantsScreen> {
   }
 
   Future<void> _load() async {
-    final data = await _service.fetchRestaurants();
+    final data = await _service.getRestaurants();
     setState(() => _restaurants = data);
   }
 


### PR DESCRIPTION
## Summary
- Correct admin screens to use existing `restaurant` and `menu_item` models
- Replace nonexistent `RestaurantService` with `DatabaseService`
- Load menu items from the database when managing menus

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*
- `apt-get install -y dart` *(fails: unable to locate package)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894896def108323bfb4479cd9d85cc7