### PR TITLE
Handle sqflite on web

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,10 @@ dependencies:
   permission_handler: ^11.0.1
   google_maps_flutter: ^2.5.0
   http: ^1.1.0
+  path_provider: ^2.0.15
+  sqflite_common_ffi: ^2.3.0
+  hive: ^2.2.3
+  hive_flutter: ^1.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- Skip sqflite database initialization on web and set up FFI for desktop
- Guard database calls when no database is available
- Add path_provider, sqflite_common_ffi, hive and hive_flutter dependencies

## Testing
- `flutter pub get` *(fails: command not found)*
- `dart pub get` *(fails: command not found)*
- `dart format lib/services/database_service.dart pubspec.yaml` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68948daf1cdc832383f3836aa00bcb31