### PR TITLE
fix ndk mismatch for android build

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -8,7 +8,8 @@ plugins {
 android {
     namespace = "com.example.dinehub"
     compileSdk = flutter.compileSdkVersion
-    ndkVersion = flutter.ndkVersion
+    // Pin the Android NDK version to satisfy plugin requirements
+    ndkVersion = "27.0.12077973"
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11


### PR DESCRIPTION
## Summary
- pin Android NDK version to 27.0.12077973 to satisfy Flutter plugin requirements

## Testing
- `gradle assembleRelease` *(fails: /workspace/DineHub/android/local.properties (No such file or directory))*

------
https://chatgpt.com/codex/tasks/task_e_6894a447392c832383609cdd6629f05c