### PR TITLE
Handle database errors with SnackBars

### DIFF
--- a/lib/providers/restaurant_provider.dart
+++ b/lib/providers/restaurant_provider.dart
@@ -17,15 +17,19 @@ class RestaurantProvider with ChangeNotifier {
 
   final DatabaseService _databaseService = DatabaseService();
 
-  Future<void> loadRestaurants() async {
+  Future<void> loadRestaurants(BuildContext context) async {
     _isLoading = true;
     notifyListeners();
 
     try {
       _restaurants = await _databaseService.getRestaurants();
       _filteredRestaurants = _restaurants;
-    } catch (e) {
+    } catch (e, stack) {
       debugPrint('Error loading restaurants: $e');
+      debugPrintStack(stackTrace: stack);
+      ScaffoldMessenger.maybeOf(context)?.showSnackBar(
+        const SnackBar(content: Text('Failed to load restaurants')),
+      );
     }
 
     _isLoading = false;
@@ -46,20 +50,28 @@ class RestaurantProvider with ChangeNotifier {
     notifyListeners();
   }
 
-  Future<void> loadMenuItems(int restaurantId) async {
+  Future<void> loadMenuItems(int restaurantId, BuildContext context) async {
     try {
       _currentMenuItems = await _databaseService.getMenuItems(restaurantId);
       notifyListeners();
-    } catch (e) {
+    } catch (e, stack) {
       debugPrint('Error loading menu items: $e');
+      debugPrintStack(stackTrace: stack);
+      ScaffoldMessenger.maybeOf(context)?.showSnackBar(
+        const SnackBar(content: Text('Failed to load menu items')),
+      );
     }
   }
 
-  Future<Restaurant?> getRestaurant(int id) async {
+  Future<Restaurant?> getRestaurant(int id, BuildContext context) async {
     try {
       return await _databaseService.getRestaurant(id);
-    } catch (e) {
+    } catch (e, stack) {
       debugPrint('Error getting restaurant: $e');
+      debugPrintStack(stackTrace: stack);
+      ScaffoldMessenger.maybeOf(context)?.showSnackBar(
+        const SnackBar(content: Text('Failed to load restaurant')),
+      );
       return null;
     }
   }

--- a/lib/providers/review_provider.dart
+++ b/lib/providers/review_provider.dart
@@ -11,28 +11,36 @@ class ReviewProvider with ChangeNotifier {
 
   final DatabaseService _databaseService = DatabaseService();
 
-  Future<void> loadReviews(int restaurantId) async {
+  Future<void> loadReviews(int restaurantId, BuildContext context) async {
     _isLoading = true;
     notifyListeners();
 
     try {
       _reviews = await _databaseService.getReviews(restaurantId);
-    } catch (e) {
+    } catch (e, stack) {
       debugPrint('Error loading reviews: $e');
+      debugPrintStack(stackTrace: stack);
+      ScaffoldMessenger.maybeOf(context)?.showSnackBar(
+        const SnackBar(content: Text('Failed to load reviews')),
+      );
     }
 
     _isLoading = false;
     notifyListeners();
   }
 
-  Future<bool> addReview(Review review) async {
+  Future<bool> addReview(Review review, BuildContext context) async {
     try {
       await _databaseService.addReview(review);
       // Reload reviews to get the updated list
-      await loadReviews(review.restaurantId);
+      await loadReviews(review.restaurantId, context);
       return true;
-    } catch (e) {
+    } catch (e, stack) {
       debugPrint('Error adding review: $e');
+      debugPrintStack(stackTrace: stack);
+      ScaffoldMessenger.maybeOf(context)?.showSnackBar(
+        const SnackBar(content: Text('Failed to add review')),
+      );
       return false;
     }
   }

--- a/lib/screens/restaurant_detail_screen.dart
+++ b/lib/screens/restaurant_detail_screen.dart
@@ -22,9 +22,9 @@ class _RestaurantDetailScreenState extends State<RestaurantDetailScreen> {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       Provider.of<RestaurantProvider>(context, listen: false)
-          .loadMenuItems(widget.restaurant.id!);
+          .loadMenuItems(widget.restaurant.id!, context);
       Provider.of<ReviewProvider>(context, listen: false)
-          .loadReviews(widget.restaurant.id!);
+          .loadReviews(widget.restaurant.id!, context);
     });
   }
 
@@ -110,12 +110,12 @@ class _RestaurantDetailScreenState extends State<RestaurantDetailScreen> {
                 );
 
                 final success = await Provider.of<ReviewProvider>(context, listen: false)
-                    .addReview(review);
+                    .addReview(review, context);
 
                 if (success) {
                   // Update restaurant rating in provider
                   final updatedRestaurant = await Provider.of<RestaurantProvider>(context, listen: false)
-                      .getRestaurant(widget.restaurant.id!);
+                      .getRestaurant(widget.restaurant.id!, context);
                   if (updatedRestaurant != null) {
                     Provider.of<RestaurantProvider>(context, listen: false)
                         .updateRestaurantRating(

--- a/lib/screens/splash_screen.dart
+++ b/lib/screens/splash_screen.dart
@@ -18,7 +18,8 @@ class _SplashScreenState extends State<SplashScreen> {
 
   Future<void> _initializeApp() async {
     // Load restaurants
-    await Provider.of<RestaurantProvider>(context, listen: false).loadRestaurants();
+    await Provider.of<RestaurantProvider>(context, listen: false)
+        .loadRestaurants(context);
     
     // Navigate to login screen after 2 seconds
     await Future.delayed(const Duration(seconds: 2));


### PR DESCRIPTION
## Summary
- show SnackBar messages when restaurant and review provider database calls fail
- propagate BuildContext to providers to support error UI

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_6894f46040608323a9d9ccd8162375a0