### PR TITLE
Implement review deletion and admin review management

### DIFF
--- a/lib/admin/review_management.dart
+++ b/lib/admin/review_management.dart
@@ -1,49 +1,119 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/restaurant.dart';
+import '../services/database_service.dart';
+import '../providers/review_provider.dart';
 
 class ReviewManagementScreen extends StatefulWidget {
-  const ReviewManagementScreen({super.key});
+  final int? restaurantId;
+  const ReviewManagementScreen({super.key, this.restaurantId});
 
   @override
   State<ReviewManagementScreen> createState() => _ReviewManagementScreenState();
 }
 
 class _ReviewManagementScreenState extends State<ReviewManagementScreen> {
-  final List<Map<String, dynamic>> _reviews = [
-    {'user': 'John Doe', 'rating': 8, 'comment': 'Great food!'},
-    {'user': 'Sarah Smith', 'rating': 9, 'comment': 'Amazing service!'},
-  ];
+  final DatabaseService _service = DatabaseService();
+  late final ReviewProvider _reviewProvider;
+  List<Restaurant> _restaurants = [];
+  int? _selectedRestaurantId;
+
+  @override
+  void initState() {
+    super.initState();
+    _reviewProvider = ReviewProvider();
+    _loadRestaurants();
+  }
+
+  Future<void> _loadRestaurants() async {
+    final data = await _service.getRestaurants();
+    setState(() {
+      _restaurants = data;
+      _selectedRestaurantId =
+          widget.restaurantId ?? (data.isNotEmpty ? data.first.id : null);
+    });
+    if (_selectedRestaurantId != null) {
+      await _reviewProvider.loadReviews(_selectedRestaurantId!, context);
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('Review Management')),
-      body: ListView.builder(
-        itemCount: _reviews.length,
-        itemBuilder: (context, index) {
-          final review = _reviews[index];
-          return Card(
-            margin: const EdgeInsets.all(8),
-            child: ListTile(
-              title: Text(review['user']),
-              subtitle: Text(review['comment']),
-              leading: CircleAvatar(child: Text(review['rating'].toString())),
-              trailing: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  IconButton(
-                    icon: const Icon(Icons.check, color: Colors.green),
-                    onPressed: () {},
+    return ChangeNotifierProvider<ReviewProvider>.value(
+      value: _reviewProvider,
+      child: Scaffold(
+        appBar: AppBar(title: const Text('Review Management')),
+        body: Consumer<ReviewProvider>(
+          builder: (context, provider, _) {
+            if (_selectedRestaurantId == null) {
+              return const Center(child: Text('No restaurants available'));
+            }
+            if (provider.isLoading) {
+              return const Center(child: CircularProgressIndicator());
+            }
+            return Column(
+              children: [
+                Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: DropdownButton<int>(
+                    value: _selectedRestaurantId,
+                    items: _restaurants
+                        .map(
+                          (r) => DropdownMenuItem<int>(
+                            value: r.id,
+                            child: Text(r.name),
+                          ),
+                        )
+                        .toList(),
+                    onChanged: (id) {
+                      if (id == null) return;
+                      setState(() => _selectedRestaurantId = id);
+                      provider.loadReviews(id, context);
+                    },
                   ),
-                  IconButton(
-                    icon: const Icon(Icons.close, color: Colors.red),
-                    onPressed: () {},
+                ),
+                Expanded(
+                  child: ListView.builder(
+                    itemCount: provider.reviews.length,
+                    itemBuilder: (context, index) {
+                      final review = provider.reviews[index];
+                      return Card(
+                        margin: const EdgeInsets.all(8),
+                        child: ListTile(
+                          title: Text(review.userName),
+                          subtitle: Text(review.comment),
+                          leading: CircleAvatar(
+                            child: Text(review.rating.toString()),
+                          ),
+                          trailing: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              IconButton(
+                                icon:
+                                    const Icon(Icons.check, color: Colors.green),
+                                onPressed: () {},
+                              ),
+                              IconButton(
+                                icon: const Icon(Icons.close, color: Colors.red),
+                                onPressed: () {
+                                  provider.deleteReview(
+                                      review.id!, review.restaurantId, context);
+                                },
+                              ),
+                            ],
+                          ),
+                        ),
+                      );
+                    },
                   ),
-                ],
-              ),
-            ),
-          );
-        },
+                ),
+              ],
+            );
+          },
+        ),
       ),
     );
   }
 }
+

--- a/lib/providers/review_provider.dart
+++ b/lib/providers/review_provider.dart
@@ -44,4 +44,21 @@ class ReviewProvider with ChangeNotifier {
       return false;
     }
   }
+
+  Future<bool> deleteReview(
+      int reviewId, int restaurantId, BuildContext context) async {
+    try {
+      await _databaseService.deleteReview(reviewId);
+      // Refresh local list after deletion
+      await loadReviews(restaurantId, context);
+      return true;
+    } catch (e, stack) {
+      debugPrint('Error deleting review: $e');
+      debugPrintStack(stackTrace: stack);
+      ScaffoldMessenger.maybeOf(context)?.showSnackBar(
+        const SnackBar(content: Text('Failed to delete review')),
+      );
+      return false;
+    }
+  }
 }

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -249,6 +249,30 @@ class DatabaseService {
     return reviewId;
   }
 
+  Future<void> deleteReview(int id) async {
+    final db = await database;
+    if (db == null) return;
+
+    // Get the restaurant ID before deleting the review
+    final result = await db.query(
+      'reviews',
+      where: 'id = ?',
+      whereArgs: [id],
+      limit: 1,
+    );
+
+    if (result.isEmpty) return;
+    final int restaurantId = result.first['restaurantId'] as int;
+
+    await db.delete(
+      'reviews',
+      where: 'id = ?',
+      whereArgs: [id],
+    );
+
+    await _updateRestaurantRating(restaurantId);
+  }
+
   Future<void> _updateRestaurantRating(int restaurantId) async {
     final db = await database;
     if (db == null) return;


### PR DESCRIPTION
## Summary
- add deleteReview to DatabaseService and expose it via ReviewProvider
- load and filter reviews in ReviewManagementScreen and allow deletion

## Testing
- `apt-get install -y dart` (failed: Unable to locate package dart)
- `flutter test` (fails: command not found: flutter)
- `dart test` (fails: command not found: dart)


------
https://chatgpt.com/codex/tasks/task_e_68950ea66f308323a57a53a82a3efcb0