### PR TITLE
Add provider-backed restaurant CRUD methods

### DIFF
--- a/lib/admin/add_restaurant.dart
+++ b/lib/admin/add_restaurant.dart
@@ -1,4 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../models/restaurant.dart';
+import '../providers/restaurant_provider.dart';
 
 class AddRestaurantScreen extends StatefulWidget {
   const AddRestaurantScreen({super.key});
@@ -34,7 +37,20 @@ class _AddRestaurantScreenState extends State<AddRestaurantScreen> {
             ),
             const SizedBox(height: 20),
             ElevatedButton(
-              onPressed: () => Navigator.pop(context),
+              onPressed: () async {
+                final restaurant = Restaurant(
+                  name: _nameController.text,
+                  address: _addressController.text,
+                  cuisine: _cuisineController.text,
+                  latitude: 0.0,
+                  longitude: 0.0,
+                  imageUrl: '',
+                  description: '',
+                );
+                await Provider.of<RestaurantProvider>(context, listen: false)
+                    .addRestaurant(restaurant, context);
+                Navigator.pop(context);
+              },
               child: const Text('Save'),
             ),
           ],

--- a/lib/admin/edit_restaurant.dart
+++ b/lib/admin/edit_restaurant.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import '../models/restaurant.dart';
+import '../providers/restaurant_provider.dart';
 
 class EditRestaurantScreen extends StatefulWidget {
   final Restaurant restaurant;
@@ -44,7 +46,23 @@ class _EditRestaurantScreenState extends State<EditRestaurantScreen> {
             ),
             const SizedBox(height: 20),
             ElevatedButton(
-              onPressed: () => Navigator.pop(context),
+              onPressed: () async {
+                final updated = Restaurant(
+                  id: widget.restaurant.id,
+                  name: _nameController.text,
+                  address: _addressController.text,
+                  cuisine: _cuisineController.text,
+                  latitude: widget.restaurant.latitude,
+                  longitude: widget.restaurant.longitude,
+                  imageUrl: widget.restaurant.imageUrl,
+                  description: widget.restaurant.description,
+                  rating: widget.restaurant.rating,
+                  reviewCount: widget.restaurant.reviewCount,
+                );
+                await Provider.of<RestaurantProvider>(context, listen: false)
+                    .updateRestaurant(updated, context);
+                Navigator.pop(context);
+              },
               child: const Text('Update'),
             ),
           ],

--- a/lib/providers/restaurant_provider.dart
+++ b/lib/providers/restaurant_provider.dart
@@ -76,6 +76,65 @@ class RestaurantProvider with ChangeNotifier {
     }
   }
 
+  Future<void> addRestaurant(Restaurant restaurant, BuildContext context) async {
+    try {
+      int id = await _databaseService.insertRestaurant(restaurant);
+      if (id > 0) {
+        final newRestaurant = Restaurant(
+          id: id,
+          name: restaurant.name,
+          address: restaurant.address,
+          cuisine: restaurant.cuisine,
+          latitude: restaurant.latitude,
+          longitude: restaurant.longitude,
+          imageUrl: restaurant.imageUrl,
+          description: restaurant.description,
+          rating: restaurant.rating,
+          reviewCount: restaurant.reviewCount,
+        );
+        _restaurants.add(newRestaurant);
+        searchRestaurants(_searchQuery);
+      }
+    } catch (e, stack) {
+      debugPrint('Error adding restaurant: $e');
+      debugPrintStack(stackTrace: stack);
+      ScaffoldMessenger.maybeOf(context)?.showSnackBar(
+        const SnackBar(content: Text('Failed to add restaurant')),
+      );
+    }
+  }
+
+  Future<void> updateRestaurant(Restaurant restaurant, BuildContext context) async {
+    try {
+      await _databaseService.updateRestaurant(restaurant);
+      int index = _restaurants.indexWhere((r) => r.id == restaurant.id);
+      if (index != -1) {
+        _restaurants[index] = restaurant;
+        searchRestaurants(_searchQuery);
+      }
+    } catch (e, stack) {
+      debugPrint('Error updating restaurant: $e');
+      debugPrintStack(stackTrace: stack);
+      ScaffoldMessenger.maybeOf(context)?.showSnackBar(
+        const SnackBar(content: Text('Failed to update restaurant')),
+      );
+    }
+  }
+
+  Future<void> deleteRestaurant(int id, BuildContext context) async {
+    try {
+      await _databaseService.deleteRestaurant(id);
+      _restaurants.removeWhere((r) => r.id == id);
+      searchRestaurants(_searchQuery);
+    } catch (e, stack) {
+      debugPrint('Error deleting restaurant: $e');
+      debugPrintStack(stackTrace: stack);
+      ScaffoldMessenger.maybeOf(context)?.showSnackBar(
+        const SnackBar(content: Text('Failed to delete restaurant')),
+      );
+    }
+  }
+
   void updateRestaurantRating(int restaurantId, double newRating, int newReviewCount) {
     int index = _restaurants.indexWhere((r) => r.id == restaurantId);
     if (index != -1) {

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -213,6 +213,33 @@ class DatabaseService {
     return null;
   }
 
+  Future<int> insertRestaurant(Restaurant restaurant) async {
+    final db = await database;
+    if (db == null) return 0;
+    return await db.insert('restaurants', restaurant.toMap());
+  }
+
+  Future<void> updateRestaurant(Restaurant restaurant) async {
+    final db = await database;
+    if (db == null || restaurant.id == null) return;
+    await db.update(
+      'restaurants',
+      restaurant.toMap(),
+      where: 'id = ?',
+      whereArgs: [restaurant.id],
+    );
+  }
+
+  Future<void> deleteRestaurant(int id) async {
+    final db = await database;
+    if (db == null) return;
+    await db.delete(
+      'restaurants',
+      where: 'id = ?',
+      whereArgs: [id],
+    );
+  }
+
   // Menu items operations
   Future<List<MenuItem>> getMenuItems(int restaurantId) async {
     final db = await database;


### PR DESCRIPTION
## Summary
- add insert/update/delete operations to `DatabaseService`
- expose restaurant CRUD via `RestaurantProvider` and update admin screens to use it
- refresh restaurant lists after add/update/delete so UI stays in sync

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689511562090832388dc5736d64201f0