### PR TITLE
Add logout buttons for admin and user

### DIFF
--- a/lib/admin/admin_dashboard.dart
+++ b/lib/admin/admin_dashboard.dart
@@ -8,7 +8,17 @@ class AdminDashboard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Admin Dashboard')),
+      appBar: AppBar(
+        title: const Text('Admin Dashboard'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.logout),
+            onPressed: () {
+              Navigator.pushReplacementNamed(context, '/login');
+            },
+          ),
+        ],
+      ),
       body: Padding(
         padding: const EdgeInsets.all(16.0),
         child: Column(

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -38,6 +38,14 @@ class _HomeScreenState extends State<HomeScreen> {
             ),
           ),
         ),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.logout),
+            onPressed: () {
+              Navigator.pushReplacementNamed(context, '/login');
+            },
+          ),
+        ],
       ),
       body: Column(
         children: [


### PR DESCRIPTION
## Summary
- add logout action in admin dashboard app bar
- add logout icon to user home screen app bar

## Testing
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_689535ff9adc8323afa49495bcb5470f