### PR TITLE
feat: enable image selection when adding restaurants

### DIFF
--- a/lib/admin/add_restaurant.dart
+++ b/lib/admin/add_restaurant.dart
@@ -1,4 +1,8 @@
+import 'dart:io' as io;
+
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
 import 'package:provider/provider.dart';
 import '../models/restaurant.dart';
 import '../providers/restaurant_provider.dart';
@@ -14,6 +18,8 @@ class _AddRestaurantScreenState extends State<AddRestaurantScreen> {
   final _nameController = TextEditingController();
   final _addressController = TextEditingController();
   final _cuisineController = TextEditingController();
+  final ImagePicker _picker = ImagePicker();
+  XFile? _imageFile;
 
   @override
   Widget build(BuildContext context) {
@@ -21,39 +27,61 @@ class _AddRestaurantScreenState extends State<AddRestaurantScreen> {
       appBar: AppBar(title: const Text('Add Restaurant')),
       body: Padding(
         padding: const EdgeInsets.all(16.0),
-        child: Column(
-          children: [
-            TextField(
-              controller: _nameController,
-              decoration: const InputDecoration(labelText: 'Name'),
-            ),
-            TextField(
-              controller: _addressController,
-              decoration: const InputDecoration(labelText: 'Address'),
-            ),
-            TextField(
-              controller: _cuisineController,
-              decoration: const InputDecoration(labelText: 'Cuisine'),
-            ),
-            const SizedBox(height: 20),
-            ElevatedButton(
-              onPressed: () async {
-                final restaurant = Restaurant(
-                  name: _nameController.text,
-                  address: _addressController.text,
-                  cuisine: _cuisineController.text,
-                  latitude: 0.0,
-                  longitude: 0.0,
-                  imageUrl: '',
-                  description: '',
-                );
-                await Provider.of<RestaurantProvider>(context, listen: false)
-                    .addRestaurant(restaurant, context);
-                Navigator.pop(context);
-              },
-              child: const Text('Save'),
-            ),
-          ],
+        child: SingleChildScrollView(
+          child: Column(
+            children: [
+              TextField(
+                controller: _nameController,
+                decoration: const InputDecoration(labelText: 'Name'),
+              ),
+              TextField(
+                controller: _addressController,
+                decoration: const InputDecoration(labelText: 'Address'),
+              ),
+              TextField(
+                controller: _cuisineController,
+                decoration: const InputDecoration(labelText: 'Cuisine'),
+              ),
+              const SizedBox(height: 20),
+              if (_imageFile != null)
+                SizedBox(
+                  height: 150,
+                  child: kIsWeb
+                      ? Image.network(_imageFile!.path)
+                      : Image.file(io.File(_imageFile!.path)),
+                ),
+              ElevatedButton(
+                onPressed: () async {
+                  final picked =
+                      await _picker.pickImage(source: ImageSource.gallery);
+                  if (picked != null) {
+                    setState(() {
+                      _imageFile = picked;
+                    });
+                  }
+                },
+                child: const Text('Pick Image'),
+              ),
+              const SizedBox(height: 20),
+              ElevatedButton(
+                onPressed: () async {
+                  final restaurant = Restaurant(
+                    name: _nameController.text,
+                    address: _addressController.text,
+                    cuisine: _cuisineController.text,
+                    latitude: 0.0,
+                    longitude: 0.0,
+                    imageUrl: _imageFile?.path ?? '',
+                    description: '',
+                  );
+                  await Provider.of<RestaurantProvider>(context, listen: false)
+                      .addRestaurant(restaurant, context);
+                  Navigator.pop(context);
+                },
+                child: const Text('Save'),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,6 +46,7 @@ dependencies:
   hive: ^2.2.3
   hive_flutter: ^1.1.0
   url_launcher: ^6.3.0
+  image_picker: ^1.0.4
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- allow admins to pick an image when creating a restaurant and store the selected path
- add image_picker dependency

## Testing
- `flutter pub get` *(fails: command not found)*
- `dart pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68954aa55b388323b58f5e139697dce5