### PR TITLE
Show restaurant images or placeholder

### DIFF
--- a/lib/admin/add_restaurant.dart
+++ b/lib/admin/add_restaurant.dart
@@ -49,6 +49,28 @@ class _AddRestaurantScreenState extends State<AddRestaurantScreen> {
                   child: kIsWeb
                       ? Image.network(_imageFile!.path)
                       : Image.file(io.File(_imageFile!.path)),
+                )
+              else
+                Container(
+                  height: 150,
+                  width: double.infinity,
+                  decoration: BoxDecoration(
+                    gradient: LinearGradient(
+                      colors: [
+                        Theme.of(context).primaryColor,
+                        Theme.of(context).colorScheme.secondary,
+                      ],
+                      begin: Alignment.topLeft,
+                      end: Alignment.bottomRight,
+                    ),
+                  ),
+                  child: const Center(
+                    child: Icon(
+                      Icons.restaurant,
+                      size: 80,
+                      color: Colors.white,
+                    ),
+                  ),
                 ),
               ElevatedButton(
                 onPressed: () async {

--- a/lib/admin/edit_restaurant.dart
+++ b/lib/admin/edit_restaurant.dart
@@ -65,6 +65,28 @@ class _EditRestaurantScreenState extends State<EditRestaurantScreen> {
                   child: kIsWeb
                       ? Image.network(widget.restaurant.imageUrl)
                       : Image.file(io.File(widget.restaurant.imageUrl)),
+                )
+              else
+                Container(
+                  height: 150,
+                  width: double.infinity,
+                  decoration: BoxDecoration(
+                    gradient: LinearGradient(
+                      colors: [
+                        Theme.of(context).primaryColor,
+                        Theme.of(context).colorScheme.secondary,
+                      ],
+                      begin: Alignment.topLeft,
+                      end: Alignment.bottomRight,
+                    ),
+                  ),
+                  child: const Center(
+                    child: Icon(
+                      Icons.restaurant,
+                      size: 80,
+                      color: Colors.white,
+                    ),
+                  ),
                 ),
               ElevatedButton(
                 onPressed: () async {

--- a/lib/screens/restaurant_detail_screen.dart
+++ b/lib/screens/restaurant_detail_screen.dart
@@ -1,3 +1,6 @@
+import 'dart:io' as io;
+
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../models/restaurant.dart';
@@ -163,27 +166,42 @@ class _RestaurantDetailScreenState extends State<RestaurantDetailScreen> {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             // Restaurant Header
-            Container(
-              height: 200,
-              width: double.infinity,
-              decoration: BoxDecoration(
-                gradient: LinearGradient(
-                  colors: [
-                    Theme.of(context).primaryColor,
-                    Theme.of(context).colorScheme.secondary,
-                  ],
-                  begin: Alignment.topLeft,
-                  end: Alignment.bottomRight,
+            if (widget.restaurant.imageUrl.isNotEmpty)
+              kIsWeb
+                  ? Image.network(
+                      widget.restaurant.imageUrl,
+                      height: 200,
+                      width: double.infinity,
+                      fit: BoxFit.cover,
+                    )
+                  : Image.file(
+                      io.File(widget.restaurant.imageUrl),
+                      height: 200,
+                      width: double.infinity,
+                      fit: BoxFit.cover,
+                    )
+            else
+              Container(
+                height: 200,
+                width: double.infinity,
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    colors: [
+                      Theme.of(context).primaryColor,
+                      Theme.of(context).colorScheme.secondary,
+                    ],
+                    begin: Alignment.topLeft,
+                    end: Alignment.bottomRight,
+                  ),
+                ),
+                child: const Center(
+                  child: Icon(
+                    Icons.restaurant,
+                    size: 80,
+                    color: Colors.white,
+                  ),
                 ),
               ),
-              child: const Center(
-                child: Icon(
-                  Icons.restaurant,
-                  size: 80,
-                  color: Colors.white,
-                ),
-              ),
-            ),
             
             Padding(
               padding: const EdgeInsets.all(16),

--- a/lib/widgets/restaurant_card.dart
+++ b/lib/widgets/restaurant_card.dart
@@ -1,3 +1,6 @@
+import 'dart:io' as io;
+
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:geolocator/geolocator.dart';
 import '../models/restaurant.dart';
@@ -45,27 +48,45 @@ class _RestaurantCardState extends State<RestaurantCard> {
           padding: const EdgeInsets.all(12),
           child: Row(
             children: [
-              // Restaurant Icon
-              Container(
-                width: 60,
-                height: 60,
-                decoration: BoxDecoration(
+              // Restaurant Image or Placeholder
+              if (restaurant.imageUrl.isNotEmpty)
+                ClipRRect(
                   borderRadius: BorderRadius.circular(12),
-                  gradient: LinearGradient(
-                    colors: [
-                      Theme.of(context).primaryColor,
-                      Theme.of(context).colorScheme.secondary,
-                    ],
-                    begin: Alignment.topLeft,
-                    end: Alignment.bottomRight,
+                  child: kIsWeb
+                      ? Image.network(
+                          restaurant.imageUrl,
+                          width: 60,
+                          height: 60,
+                          fit: BoxFit.cover,
+                        )
+                      : Image.file(
+                          io.File(restaurant.imageUrl),
+                          width: 60,
+                          height: 60,
+                          fit: BoxFit.cover,
+                        ),
+                )
+              else
+                Container(
+                  width: 60,
+                  height: 60,
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(12),
+                    gradient: LinearGradient(
+                      colors: [
+                        Theme.of(context).primaryColor,
+                        Theme.of(context).colorScheme.secondary,
+                      ],
+                      begin: Alignment.topLeft,
+                      end: Alignment.bottomRight,
+                    ),
+                  ),
+                  child: const Icon(
+                    Icons.restaurant,
+                    color: Colors.white,
+                    size: 30,
                   ),
                 ),
-                child: const Icon(
-                  Icons.restaurant,
-                  color: Colors.white,
-                  size: 30,
-                ),
-              ),
               
               const SizedBox(width: 12),
               


### PR DESCRIPTION
## Summary
- Display restaurant images in cards and detail screens when available, otherwise fall back to gradient placeholder with restaurant icon
- Use same placeholder for restaurant image previews in add/edit admin screens

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68955153a3648323bfb80c77b6b3a863